### PR TITLE
For /dev/pts/* files, set O_NONBLOCK

### DIFF
--- a/src/rule.h
+++ b/src/rule.h
@@ -41,6 +41,7 @@ struct zlog_rule_s {
 
 	unsigned int file_perms;
 	int file_open_flags;
+	int file_fcntl_flags;
 
 	char file_path[MAXLEN_PATH + 1];
 	zc_arraylist_t *dynamic_specs;


### PR DESCRIPTION
This avoids blocking write() calls inside zlog code in some situations.
For instance, when an SSH session is stalled, its /dev/pts/* associated
file remains present, but the write() operation takes from seconds to
minutes before it returns an error. During this time, the application
generating the log is blocked. Other files can also have the same issue,
such as those mounted using NFS.

This code needs to be improved to allow choosing between
blocking/non-blocking I/O using a configuration file. By now, all files
containing "/dev/pts/" use O_NONBLOCK.

Signed-off-by: Eduardo Witter <witter@datacom.ind.br>